### PR TITLE
feat: Add initial implementation of add module which supports a helm release and IAM role for service accounts (IRSA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,122 @@
 # AWS EKS Addon Terraform module
 
-Terraform module which provisions an addon on AWS EKS clusters.
+Terraform module which provisions an addon ([Helm release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release)) and an [IAM role for service accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
 
 ## Usage
+
+### Create Addon (Helm Release) w/ IAM Role for Service Account (IRSA)
 
 ```hcl
 module "eks_addon" {
   source = "aws-ia/eks-addon/aws"
 
-  ## TODO
+  chart            = "karpenter"
+  chart_version    = "0.16.2"
+  repository       = "https://charts.karpenter.sh/"
+  description      = "Kubernetes Node Autoscaling: built for flexibility, performance, and simplicity"
+  namespace        = "karpenter"
+  create_namespace = true
+
+  set = [
+    {
+      name  = "clusterName"
+      value = "eks-addon-example"
+    },
+    {
+      name  = "clusterEndpoint"
+      value = "https://EXAMPLED539D4633E53DE1B71EXAMPLE.gr7.us-west-2.eks.amazonaws.com"
+    },
+    {
+      name  = "aws.defaultInstanceProfile"
+      value = "arn:aws:iam::111111111111:instance-profile/KarpenterNodeInstanceProfile-complete"
+    }
+  ]
+
+  set_irsa_name = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+  # # Equivalent to the following but the ARN is only known internally to the module
+  # set = [{
+  #   name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+  #   value = iam_role_arn.this[0].arn
+  # }]
+
+  # IAM role for service account (IRSA)
+  create_role = true
+  role_name   = "karpenter-controller"
+  role_policy_arns = {
+    karpenter = "arn:aws:iam::111111111111:policy/Karpenter_Controller_Policy-20221008165117447500000007"
+  }
+
+  oidc_providers = {
+    this = {
+      provider_arn = "oidc.eks.us-west-2.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE"
+      # namespace is inherited from chart
+      service_account = "karpenter"
+    }
+  }
+
+  tags = {
+    Environment = "dev"
+  }
+}
+```
+
+### Create Addon (Helm Release) Only
+
+```hcl
+module "eks_addon" {
+  source = "aws-ia/eks-addon/aws"
+
+  chart         = "metrics-server"
+  chart_version = "3.8.2"
+  repository    = "https://kubernetes-sigs.github.io/metrics-server/"
+  description   = "Metric server helm Chart deployment configuration"
+  namespace     = "kube-system"
+
+  values = [
+    <<-EOT
+      podDisruptionBudget:
+        maxUnavailable: 1
+      metrics:
+        enabled: true
+    EOT
+  ]
+
+  set = [
+    {
+      name  = "replicas"
+      value = 3
+    }
+  ]
+}
+```
+
+### Create IAM Role for Service Account (IRSA) Only
+
+```hcl
+module "eks_addon" {
+  source = "aws-ia/eks-addon/aws"
+
+  # Disable helm release
+  create_release = false
+
+  # IAM role for service account (IRSA)
+  create_role = true
+  role_name   = "aws-vpc-cni-ipv4"
+  role_policy_arns = {
+    AmazonEKS_CNI_Policy = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  }
+
+  oidc_providers = {
+    this = {
+      provider_arn    = "oidc.eks.us-west-2.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE"
+      namespace       = "kube-system"
+      service_account = "aws-node"
+    }
+  }
+
+  tags = {
+    Environment = "dev"
+  }
 }
 ```
 
@@ -31,6 +139,7 @@ Examples codified under the [`examples`](https://github.com/aws-ia/terraform-aws
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.6 |
 
 ## Modules
@@ -41,12 +150,19 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allow_self_assume_role"></a> [allow\_self\_assume\_role](#input\_allow\_self\_assume\_role) | Determines whether to allow the role to be [assume itself](https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/) | `bool` | `false` | no |
+| <a name="input_assume_role_condition_test"></a> [assume\_role\_condition\_test](#input\_assume\_role\_condition\_test) | Name of the [IAM condition operator](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html) to evaluate when assuming the role | `string` | `"StringEquals"` | no |
 | <a name="input_atomic"></a> [atomic](#input\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used. Defaults to `false` | `bool` | `null` | no |
 | <a name="input_chart"></a> [chart](#input\_chart) | Chart name to be installed. The chart name can be local path, a URL to a chart, or the name of the chart if `repository` is specified | `string` | `""` | no |
 | <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Specify the exact chart version to install. If this is not specified, the latest version is installed | `string` | `null` | no |
@@ -54,17 +170,21 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create the namespace if it does not yet exist. Defaults to `false` | `bool` | `null` | no |
 | <a name="input_create_release"></a> [create\_release](#input\_create\_release) | Determines whether the Helm release is created | `bool` | `true` | no |
+| <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Whether to create a role | `bool` | `false` | no |
 | <a name="input_dependency_update"></a> [dependency\_update](#input\_dependency\_update) | Runs helm dependency update before installing the chart. Defaults to `false` | `bool` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | Set release description attribute (visible in the history) | `string` | `null` | no |
 | <a name="input_devel"></a> [devel](#input\_devel) | Use chart development versions, too. Equivalent to version '>0.0.0-0'. If version is set, this is ignored | `bool` | `null` | no |
 | <a name="input_disable_openapi_validation"></a> [disable\_openapi\_validation](#input\_disable\_openapi\_validation) | If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false` | `bool` | `null` | no |
 | <a name="input_disable_webhooks"></a> [disable\_webhooks](#input\_disable\_webhooks) | Prevent hooks from running. Defaults to `false` | `bool` | `null` | no |
+| <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `true` | no |
 | <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. Defaults to `false` | `bool` | `null` | no |
 | <a name="input_keyring"></a> [keyring](#input\_keyring) | Location of public keys used for verification. Used only if verify is true. Defaults to `/.gnupg/pubring.gpg` in the location set by `home` | `string` | `null` | no |
 | <a name="input_lint"></a> [lint](#input\_lint) | Run the helm chart linter during the plan. Defaults to `false` | `bool` | `null` | no |
 | <a name="input_max_history"></a> [max\_history](#input\_max\_history) | Maximum number of release versions stored per release. Defaults to `0` (no limit) | `number` | `null` | no |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the Helm release | `string` | `""` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The namespace to install the release into. Defaults to `default` | `string` | `null` | no |
+| <a name="input_oidc_providers"></a> [oidc\_providers](#input\_oidc\_providers) | Map of OIDC providers where each provider map should contain the `provider_arn`, and `service_accounts` | `any` | `{}` | no |
 | <a name="input_postrender"></a> [postrender](#input\_postrender) | Configure a command to run after helm renders the manifest which can alter the manifest contents | `any` | `{}` | no |
 | <a name="input_recreate_pods"></a> [recreate\_pods](#input\_recreate\_pods) | Perform pods restart during upgrade/rollback. Defaults to `false` | `bool` | `null` | no |
 | <a name="input_render_subchart_notes"></a> [render\_subchart\_notes](#input\_render\_subchart\_notes) | If set, render subchart notes along with the parent. Defaults to `true` | `bool` | `null` | no |
@@ -77,9 +197,17 @@ No modules.
 | <a name="input_repository_username"></a> [repository\_username](#input\_repository\_username) | Username for HTTP basic authentication against the repository | `string` | `null` | no |
 | <a name="input_reset_values"></a> [reset\_values](#input\_reset\_values) | When upgrading, reset the values to the ones built into the chart. Defaults to `false` | `bool` | `null` | no |
 | <a name="input_reuse_values"></a> [reuse\_values](#input\_reuse\_values) | When upgrading, reuse the last release's values and merge in any overrides. If `reset_values` is specified, this is ignored. Defaults to `false` | `bool` | `null` | no |
+| <a name="input_role_description"></a> [role\_description](#input\_role\_description) | IAM Role description | `string` | `null` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of IAM role | `string` | `null` | no |
+| <a name="input_role_name_use_prefix"></a> [role\_name\_use\_prefix](#input\_role\_name\_use\_prefix) | Determines whether the IAM role name (`role_name`) is used as a prefix | `bool` | `true` | no |
+| <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Path of IAM role | `string` | `"/"` | no |
+| <a name="input_role_permissions_boundary_arn"></a> [role\_permissions\_boundary\_arn](#input\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `null` | no |
+| <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | ARNs of any policies to attach to the IAM role | `map(string)` | `{}` | no |
 | <a name="input_set"></a> [set](#input\_set) | Value block with custom values to be merged with the values yaml | `any` | `[]` | no |
+| <a name="input_set_irsa_name"></a> [set\_irsa\_name](#input\_set\_irsa\_name) | Value annotation name where IRSA role ARN created by module will be assigned to the `value` | `string` | `""` | no |
 | <a name="input_set_sensitive"></a> [set\_sensitive](#input\_set\_sensitive) | Value block with custom sensitive values to be merged with the values yaml that won't be exposed in the plan's diff | `any` | `[]` | no |
 | <a name="input_skip_crds"></a> [skip\_crds](#input\_skip\_crds) | If set, no CRDs will be installed. By default, CRDs are installed if not already present. Defaults to `false` | `bool` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add the the IAM role | `map(any)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds | `number` | `null` | no |
 | <a name="input_values"></a> [values](#input\_values) | List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options | `list(string)` | `null` | no |
 | <a name="input_verify"></a> [verify](#input\_verify) | Verify the package before installing it. Helm uses a provenance file to verify the integrity of the chart; this must be hosted alongside the chart. For more information see the Helm Documentation. Defaults to `false` | `bool` | `null` | no |
@@ -92,6 +220,10 @@ No modules.
 |------|-------------|
 | <a name="output_app_version"></a> [app\_version](#output\_app\_version) | The version number of the application being deployed |
 | <a name="output_chart"></a> [chart](#output\_chart) | The name of the chart |
+| <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | Name of IAM role |
+| <a name="output_iam_role_path"></a> [iam\_role\_path](#output\_iam\_role\_path) | Path of IAM role |
+| <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Unique ID of IAM role |
 | <a name="output_name"></a> [name](#output\_name) | Name is the name of the release |
 | <a name="output_namespace"></a> [namespace](#output\_namespace) | Name of Kubernetes namespace |
 | <a name="output_revision"></a> [revision](#output\_revision) | Version is an int32 which represents the version of the release |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,7 +1,10 @@
 # Complete AWS EKS Addon Example
 
 Configuration in this directory provisions:
-- TODO
+- An EKS cluster and VPC used to support the example
+- An addon (Helm release) for [`metrics-server`](https://github.com/kubernetes-sigs/metrics-server) without an IAM role for service account (IRSA)
+- An addon (Helm release) for [`karpenter`](https://github.com/aws/karpenter) with an IAM role for service account (IRSA)
+- An IAM role for service account (IRSA) suitable for use by the [AWS VPC-CNI](https://github.com/aws/amazon-vpc-cni-k8s)
 
 ## Usage
 
@@ -23,12 +26,14 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.6 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.14 |
 
 ## Modules
 
@@ -36,15 +41,24 @@ Note that this example may create resources which will incur monetary charges on
 |------|--------|---------|
 | <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../ | n/a |
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 18.30 |
+| <a name="module_helm_release_irsa"></a> [helm\_release\_irsa](#module\_helm\_release\_irsa) | ../../ | n/a |
 | <a name="module_helm_release_only"></a> [helm\_release\_only](#module\_helm\_release\_only) | ../../ | n/a |
+| <a name="module_irsa_only"></a> [irsa\_only](#module\_irsa\_only) | ../../ | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_iam_instance_profile.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_policy.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [kubectl_manifest.karpenter_example_deployment](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.karpenter_node_template](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.karpenter_provisioner](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+| [aws_iam_policy_document.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -54,13 +68,39 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_helm_release_irsa_app_version"></a> [helm\_release\_irsa\_app\_version](#output\_helm\_release\_irsa\_app\_version) | The version number of the application being deployed |
+| <a name="output_helm_release_irsa_chart"></a> [helm\_release\_irsa\_chart](#output\_helm\_release\_irsa\_chart) | The name of the chart |
+| <a name="output_helm_release_irsa_iam_role_arn"></a> [helm\_release\_irsa\_iam\_role\_arn](#output\_helm\_release\_irsa\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_helm_release_irsa_iam_role_name"></a> [helm\_release\_irsa\_iam\_role\_name](#output\_helm\_release\_irsa\_iam\_role\_name) | Name of IAM role |
+| <a name="output_helm_release_irsa_iam_role_path"></a> [helm\_release\_irsa\_iam\_role\_path](#output\_helm\_release\_irsa\_iam\_role\_path) | Path of IAM role |
+| <a name="output_helm_release_irsa_iam_role_unique_id"></a> [helm\_release\_irsa\_iam\_role\_unique\_id](#output\_helm\_release\_irsa\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_helm_release_irsa_name"></a> [helm\_release\_irsa\_name](#output\_helm\_release\_irsa\_name) | Name is the name of the release |
+| <a name="output_helm_release_irsa_namespace"></a> [helm\_release\_irsa\_namespace](#output\_helm\_release\_irsa\_namespace) | Name of Kubernetes namespace |
+| <a name="output_helm_release_irsa_revision"></a> [helm\_release\_irsa\_revision](#output\_helm\_release\_irsa\_revision) | Version is an int32 which represents the version of the release |
+| <a name="output_helm_release_irsa_values"></a> [helm\_release\_irsa\_values](#output\_helm\_release\_irsa\_values) | The compounded values from `values` and `set*` attributes |
+| <a name="output_helm_release_irsa_version"></a> [helm\_release\_irsa\_version](#output\_helm\_release\_irsa\_version) | A SemVer 2 conformant version string of the chart |
 | <a name="output_helm_release_only_app_version"></a> [helm\_release\_only\_app\_version](#output\_helm\_release\_only\_app\_version) | The version number of the application being deployed |
 | <a name="output_helm_release_only_chart"></a> [helm\_release\_only\_chart](#output\_helm\_release\_only\_chart) | The name of the chart |
+| <a name="output_helm_release_only_iam_role_arn"></a> [helm\_release\_only\_iam\_role\_arn](#output\_helm\_release\_only\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_helm_release_only_iam_role_name"></a> [helm\_release\_only\_iam\_role\_name](#output\_helm\_release\_only\_iam\_role\_name) | Name of IAM role |
+| <a name="output_helm_release_only_iam_role_path"></a> [helm\_release\_only\_iam\_role\_path](#output\_helm\_release\_only\_iam\_role\_path) | Path of IAM role |
+| <a name="output_helm_release_only_iam_role_unique_id"></a> [helm\_release\_only\_iam\_role\_unique\_id](#output\_helm\_release\_only\_iam\_role\_unique\_id) | Unique ID of IAM role |
 | <a name="output_helm_release_only_name"></a> [helm\_release\_only\_name](#output\_helm\_release\_only\_name) | Name is the name of the release |
 | <a name="output_helm_release_only_namespace"></a> [helm\_release\_only\_namespace](#output\_helm\_release\_only\_namespace) | Name of Kubernetes namespace |
 | <a name="output_helm_release_only_revision"></a> [helm\_release\_only\_revision](#output\_helm\_release\_only\_revision) | Version is an int32 which represents the version of the release |
 | <a name="output_helm_release_only_values"></a> [helm\_release\_only\_values](#output\_helm\_release\_only\_values) | The compounded values from `values` and `set*` attributes |
 | <a name="output_helm_release_only_version"></a> [helm\_release\_only\_version](#output\_helm\_release\_only\_version) | A SemVer 2 conformant version string of the chart |
+| <a name="output_irsa_only_app_version"></a> [irsa\_only\_app\_version](#output\_irsa\_only\_app\_version) | The version number of the application being deployed |
+| <a name="output_irsa_only_chart"></a> [irsa\_only\_chart](#output\_irsa\_only\_chart) | The name of the chart |
+| <a name="output_irsa_only_iam_role_arn"></a> [irsa\_only\_iam\_role\_arn](#output\_irsa\_only\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_irsa_only_iam_role_name"></a> [irsa\_only\_iam\_role\_name](#output\_irsa\_only\_iam\_role\_name) | Name of IAM role |
+| <a name="output_irsa_only_iam_role_path"></a> [irsa\_only\_iam\_role\_path](#output\_irsa\_only\_iam\_role\_path) | Path of IAM role |
+| <a name="output_irsa_only_iam_role_unique_id"></a> [irsa\_only\_iam\_role\_unique\_id](#output\_irsa\_only\_iam\_role\_unique\_id) | Unique ID of IAM role |
+| <a name="output_irsa_only_name"></a> [irsa\_only\_name](#output\_irsa\_only\_name) | Name is the name of the release |
+| <a name="output_irsa_only_namespace"></a> [irsa\_only\_namespace](#output\_irsa\_only\_namespace) | Name of Kubernetes namespace |
+| <a name="output_irsa_only_revision"></a> [irsa\_only\_revision](#output\_irsa\_only\_revision) | Version is an int32 which represents the version of the release |
+| <a name="output_irsa_only_values"></a> [irsa\_only\_values](#output\_irsa\_only\_values) | The compounded values from `values` and `set*` attributes |
+| <a name="output_irsa_only_version"></a> [irsa\_only\_version](#output\_irsa\_only\_version) | A SemVer 2 conformant version string of the chart |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/aws-ia/terraform-aws-eks-addon/blob/main/LICENSE).

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,18 +10,30 @@ provider "helm" {
   }
 }
 
+provider "kubectl" {
+  apply_retry_count      = 30
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  load_config_file       = false
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
 data "aws_eks_cluster_auth" "this" {
   name = module.eks.cluster_id
 }
 
+data "aws_caller_identity" "current" {}
 data "aws_availability_zones" "available" {}
 
 locals {
-  name   = basename(path.cwd)
-  region = "us-west-2"
+  name       = basename(path.cwd)
+  region     = "us-west-2"
+  account_id = data.aws_caller_identity.current.account_id
 
   vpc_cidr = "10.0.0.0/16"
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  karpenter_tag_key = "karpenter.sh/discovery/${local.name}"
 
   tags = {
     Example    = local.name
@@ -59,9 +71,84 @@ module "helm_release_only" {
   ]
 }
 
+module "helm_release_irsa" {
+  source = "../../"
+
+  chart            = "karpenter"
+  chart_version    = "0.16.2"
+  repository       = "https://charts.karpenter.sh/"
+  description      = "Kubernetes Node Autoscaling: built for flexibility, performance, and simplicity"
+  namespace        = "karpenter"
+  create_namespace = true
+
+  set = [
+    {
+      name  = "clusterName"
+      value = module.eks.cluster_id
+    },
+    {
+      name  = "clusterEndpoint"
+      value = module.eks.cluster_endpoint
+    },
+    {
+      name  = "aws.defaultInstanceProfile"
+      value = aws_iam_instance_profile.karpenter.name
+    }
+  ]
+
+  set_irsa_name = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+  # # Equivalent to the following but the ARN is only known internally to the module
+  # set = [{
+  #   name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+  #   value = iam_role_arn.this[0].arn
+  # }]
+
+  # IAM role for service account (IRSA)
+  create_role = true
+  role_name   = "karpenter-controller"
+  role_policy_arns = {
+    karpenter = aws_iam_policy.karpenter_controller.arn
+  }
+
+  oidc_providers = {
+    this = {
+      provider_arn = module.eks.oidc_provider_arn
+      # namespace is inherited from chart
+      service_account = "karpenter"
+    }
+  }
+
+  tags = local.tags
+}
+
+module "irsa_only" {
+  source = "../../"
+
+  # Disable helm release
+  create_release = false
+
+  # IAM role for service account (IRSA)
+  create_role = true
+  role_name   = "aws-vpc-cni-ipv4"
+  role_policy_arns = {
+    AmazonEKS_CNI_Policy = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  }
+
+  oidc_providers = {
+    this = {
+      provider_arn    = module.eks.oidc_provider_arn
+      namespace       = "kube-system"
+      service_account = "aws-node"
+    }
+  }
+
+  tags = local.tags
+}
+
 module "disabled" {
   source = "../../"
 
+  create = false
 }
 
 ################################################################################
@@ -79,18 +166,40 @@ module "eks" {
   subnet_ids               = module.vpc.private_subnets
   control_plane_subnet_ids = module.vpc.intra_subnets
 
-  eks_managed_node_groups = {
-    initial = {
-      instance_types        = ["m5.large"]
-      create_security_group = false
-
-      min_size     = 1
-      max_size     = 5
-      desired_size = 2
+  node_security_group_additional_rules = {
+    # Control plane invoke Karpenter webhook
+    ingress_karpenter_webhook_tcp = {
+      description                   = "Control plane invoke Karpenter webhook"
+      protocol                      = "tcp"
+      from_port                     = 8443
+      to_port                       = 8443
+      type                          = "ingress"
+      source_cluster_security_group = true
     }
   }
 
-  tags = local.tags
+  eks_managed_node_groups = {
+    initial = {
+      instance_types        = ["m5.xlarge"]
+      create_security_group = false
+
+      min_size     = 1
+      max_size     = 2
+      desired_size = 1
+
+      iam_role_additional_policies = [
+        # Required by Karpenter
+        "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+      ]
+    }
+  }
+
+  tags = merge(local.tags, {
+    # NOTE - if creating multiple security groups with this module, only tag the
+    # security group that Karpenter should utilize with the following tag
+    # (i.e. - at most, only one security group should have this tag in your account)
+    (local.karpenter_tag_key) = local.name
+  })
 }
 
 module "vpc" {
@@ -123,7 +232,179 @@ module "vpc" {
 
   private_subnet_tags = {
     "kubernetes.io/role/internal-elb" = 1
+    # Tags subnets for Karpenter auto-discovery
+    (local.karpenter_tag_key) = local.name
   }
 
   tags = local.tags
+}
+
+resource "aws_iam_instance_profile" "karpenter" {
+  name = "KarpenterNodeInstanceProfile-${local.name}"
+  role = module.eks.eks_managed_node_groups["initial"].iam_role_name
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "karpenter_controller" {
+  statement {
+    actions = [
+      "ec2:CreateLaunchTemplate",
+      "ec2:CreateFleet",
+      "ec2:CreateTags",
+      "ec2:DescribeLaunchTemplates",
+      "ec2:DescribeImages",
+      "ec2:DescribeInstances",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeInstanceTypeOfferings",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeSpotPriceHistory",
+      "pricing:GetProducts",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "ec2:TerminateInstances",
+      "ec2:DeleteLaunchTemplate",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:ResourceTag/${local.karpenter_tag_key}"
+      values   = [module.eks.cluster_id]
+    }
+  }
+
+  statement {
+    actions = ["ec2:RunInstances"]
+    resources = [
+      "arn:aws:ec2:*:${local.account_id}:launch-template/*",
+      "arn:aws:ec2:*:${local.account_id}:security-group/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:ResourceTag/${local.karpenter_tag_key}"
+      values   = [module.eks.cluster_id]
+    }
+  }
+
+  statement {
+    actions = ["ec2:RunInstances"]
+    resources = [
+      "arn:aws:ec2:*::image/*",
+      "arn:aws:ec2:*:${local.account_id}:instance/*",
+      "arn:aws:ec2:*:${local.account_id}:spot-instances-request/*",
+      "arn:aws:ec2:*:${local.account_id}:volume/*",
+      "arn:aws:ec2:*:${local.account_id}:network-interface/*",
+      "arn:aws:ec2:*:${local.account_id}:subnet/*",
+    ]
+  }
+
+  statement {
+    actions   = ["ssm:GetParameter"]
+    resources = ["arn:aws:ssm:*:*:parameter/aws/service/*"]
+  }
+
+  statement {
+    actions   = ["iam:PassRole"]
+    resources = [module.eks.eks_managed_node_groups["initial"].iam_role_arn]
+  }
+}
+
+resource "aws_iam_policy" "karpenter_controller" {
+  name_prefix = "Karpenter_Controller_Policy-"
+  description = "Provides permissions to handle node termination events via the Node Termination Handler"
+  policy      = data.aws_iam_policy_document.karpenter_controller.json
+
+  tags = local.tags
+}
+
+################################################################################
+# Karpenter Provisioner
+################################################################################
+
+# Workaround - https://github.com/hashicorp/terraform-provider-kubernetes/issues/1380#issuecomment-967022975
+resource "kubectl_manifest" "karpenter_provisioner" {
+  yaml_body = <<-YAML
+    ---
+    apiVersion: karpenter.sh/v1alpha5
+    kind: Provisioner
+    metadata:
+      name: default
+    spec:
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot"]
+      limits:
+        resources:
+          cpu: 1000
+      providerRef:
+        name: default
+      ttlSecondsAfterEmpty: 30
+  YAML
+
+  depends_on = [
+    module.helm_release_irsa.helm_release
+  ]
+}
+
+resource "kubectl_manifest" "karpenter_node_template" {
+  yaml_body = <<-YAML
+    apiVersion: karpenter.k8s.aws/v1alpha1
+    kind: AWSNodeTemplate
+    metadata:
+      name: default
+    spec:
+      subnetSelector:
+        ${local.karpenter_tag_key}: ${module.eks.cluster_id}
+      securityGroupSelector:
+        ${local.karpenter_tag_key}: ${module.eks.cluster_id}
+      tags:
+        ${local.karpenter_tag_key}: ${module.eks.cluster_id}
+  YAML
+
+  depends_on = [
+    kubectl_manifest.karpenter_provisioner
+  ]
+}
+
+# Example deployment using the [pause image](https://www.ianlewis.org/en/almighty-pause-container)
+# and starts with zero replicas
+resource "kubectl_manifest" "karpenter_example_deployment" {
+  yaml_body = <<-YAML
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: inflate
+  spec:
+    replicas: 0
+    selector:
+      matchLabels:
+        app: inflate
+    template:
+      metadata:
+        labels:
+          app: inflate
+      spec:
+        terminationGracePeriodSeconds: 0
+        containers:
+          - name: inflate
+            image: public.ecr.aws/eks-distro/kubernetes/pause:3.2
+            resources:
+              requests:
+                cpu: 1
+  YAML
+
+  depends_on = [
+    kubectl_manifest.karpenter_node_template
+  ]
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -36,3 +36,141 @@ output "helm_release_only_values" {
   description = "The compounded values from `values` and `set*` attributes"
   value       = module.helm_release_only.values
 }
+
+output "helm_release_only_iam_role_arn" {
+  description = "ARN of IAM role"
+  value       = module.helm_release_only.iam_role_arn
+}
+
+output "helm_release_only_iam_role_name" {
+  description = "Name of IAM role"
+  value       = module.helm_release_only.iam_role_name
+}
+
+output "helm_release_only_iam_role_path" {
+  description = "Path of IAM role"
+  value       = module.helm_release_only.iam_role_path
+}
+
+output "helm_release_only_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.helm_release_only.iam_role_unique_id
+}
+
+################################################################################
+# Helm Release & IRSA
+################################################################################
+
+output "helm_release_irsa_chart" {
+  description = "The name of the chart"
+  value       = module.helm_release_irsa.chart
+}
+
+output "helm_release_irsa_name" {
+  description = "Name is the name of the release"
+  value       = module.helm_release_irsa.name
+}
+
+output "helm_release_irsa_namespace" {
+  description = "Name of Kubernetes namespace"
+  value       = module.helm_release_irsa.namespace
+}
+
+output "helm_release_irsa_revision" {
+  description = "Version is an int32 which represents the version of the release"
+  value       = module.helm_release_irsa.revision
+}
+
+output "helm_release_irsa_version" {
+  description = "A SemVer 2 conformant version string of the chart"
+  value       = module.helm_release_irsa.version
+}
+
+output "helm_release_irsa_app_version" {
+  description = "The version number of the application being deployed"
+  value       = module.helm_release_irsa.app_version
+}
+
+output "helm_release_irsa_values" {
+  description = "The compounded values from `values` and `set*` attributes"
+  value       = module.helm_release_irsa.values
+}
+
+output "helm_release_irsa_iam_role_arn" {
+  description = "ARN of IAM role"
+  value       = module.helm_release_irsa.iam_role_arn
+}
+
+output "helm_release_irsa_iam_role_name" {
+  description = "Name of IAM role"
+  value       = module.helm_release_irsa.iam_role_name
+}
+
+output "helm_release_irsa_iam_role_path" {
+  description = "Path of IAM role"
+  value       = module.helm_release_irsa.iam_role_path
+}
+
+output "helm_release_irsa_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.helm_release_irsa.iam_role_unique_id
+}
+
+################################################################################
+# IRSA Only
+################################################################################
+
+output "irsa_only_chart" {
+  description = "The name of the chart"
+  value       = module.irsa_only.chart
+}
+
+output "irsa_only_name" {
+  description = "Name is the name of the release"
+  value       = module.irsa_only.name
+}
+
+output "irsa_only_namespace" {
+  description = "Name of Kubernetes namespace"
+  value       = module.irsa_only.namespace
+}
+
+output "irsa_only_revision" {
+  description = "Version is an int32 which represents the version of the release"
+  value       = module.irsa_only.revision
+}
+
+output "irsa_only_version" {
+  description = "A SemVer 2 conformant version string of the chart"
+  value       = module.irsa_only.version
+}
+
+output "irsa_only_app_version" {
+  description = "The version number of the application being deployed"
+  value       = module.irsa_only.app_version
+}
+
+output "irsa_only_values" {
+  description = "The compounded values from `values` and `set*` attributes"
+  value       = module.irsa_only.values
+}
+
+output "irsa_only_iam_role_arn" {
+  description = "ARN of IAM role"
+  value       = module.irsa_only.iam_role_arn
+}
+
+output "irsa_only_iam_role_name" {
+  description = "Name of IAM role"
+  value       = module.irsa_only.iam_role_name
+}
+
+output "irsa_only_iam_role_path" {
+  description = "Path of IAM role"
+  value       = module.irsa_only.iam_role_path
+}
+
+output "irsa_only_iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.irsa_only.iam_role_unique_id
+}

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.6"
     }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.14"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ locals {
 resource "helm_release" "this" {
   count = var.create && var.create_release ? 1 : 0
 
-  name             = try(coalesce(var.name, var.chart))
+  name             = try(coalesce(var.name, var.chart), "")
   description      = var.description
   namespace        = local.namespace
   create_namespace = var.create_namespace
@@ -57,9 +57,18 @@ resource "helm_release" "this" {
     for_each = var.set
 
     content {
-      name  = try(set.value.name, set.key)
+      name  = set.value.name
       value = set.value.value
       type  = try(set.value.type, null)
+    }
+  }
+
+  dynamic "set" {
+    for_each = { for k, v in { "name" = var.set_irsa_name } : k => v if var.create && var.create_role && var.set_irsa_name != "" }
+
+    content {
+      name  = set.value
+      value = aws_iam_role.this[0].arn
     }
   }
 
@@ -67,9 +76,100 @@ resource "helm_release" "this" {
     for_each = var.set_sensitive
 
     content {
-      name  = try(set_sensitive.value.name, set_sensitive.key)
+      name  = set_sensitive.value.name
       value = set_sensitive.value.value
       type  = try(set_sensitive.value.type, null)
     }
   }
+}
+
+################################################################################
+# IAM Role for Service Account(s) (IRSA)
+################################################################################
+
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  partition  = data.aws_partition.current.partition
+
+  role_name           = try(coalesce(var.role_name, var.name), "")
+  role_name_condition = var.role_name_use_prefix ? local.role_name : "${local.role_name}-*"
+}
+
+data "aws_iam_policy_document" "this" {
+  count = var.create_role && length(var.role_policy_arns) > 0 ? 1 : 0
+
+  dynamic "statement" {
+    # https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/
+    for_each = var.allow_self_assume_role ? [1] : []
+
+    content {
+      sid     = "ExplicitSelfRoleAssumption"
+      effect  = "Allow"
+      actions = ["sts:AssumeRole"]
+
+      principals {
+        type        = "AWS"
+        identifiers = ["*"]
+      }
+
+      condition {
+        test     = "ArnLike"
+        variable = "aws:PrincipalArn"
+        values   = ["arn:${local.partition}:iam::${local.account_id}:role${var.role_path}${local.role_name_condition}"]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.oidc_providers
+
+    content {
+      effect  = "Allow"
+      actions = ["sts:AssumeRoleWithWebIdentity"]
+
+      principals {
+        type        = "Federated"
+        identifiers = [statement.value.provider_arn]
+      }
+
+      condition {
+        test     = var.assume_role_condition_test
+        variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:sub"
+        values   = ["system:serviceaccount:${try(statement.value.namespace, local.namespace)}:${statement.value.service_account}"]
+      }
+
+      # https://aws.amazon.com/premiumsupport/knowledge-center/eks-troubleshoot-oidc-and-irsa/?nc1=h_ls
+      condition {
+        test     = var.assume_role_condition_test
+        variable = "${replace(statement.value.provider_arn, "/^(.*provider/)/", "")}:aud"
+        values   = ["sts.amazonaws.com"]
+      }
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  count = var.create_role ? 1 : 0
+
+  name        = var.role_name_use_prefix ? null : local.role_name
+  name_prefix = var.role_name_use_prefix ? "${local.role_name}-" : null
+  path        = var.role_path
+  description = var.role_description
+
+  assume_role_policy    = data.aws_iam_policy_document.this[0].json
+  max_session_duration  = var.max_session_duration
+  permissions_boundary  = var.role_permissions_boundary_arn
+  force_detach_policies = var.force_detach_policies
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  for_each = { for k, v in var.role_policy_arns : k => v if var.create_role }
+
+  role       = aws_iam_role.this[0].name
+  policy_arn = each.value
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,5 +34,29 @@ output "app_version" {
 
 output "values" {
   description = "The compounded values from `values` and `set*` attributes"
-  value       = jsondecode(try(helm_release.this[0].metadata[0].values, []))
+  value       = try(helm_release.this[0].metadata[0].values, [])
+}
+
+################################################################################
+# IAM Role for Service Account(s) (IRSA)
+################################################################################
+
+output "iam_role_arn" {
+  description = "ARN of IAM role"
+  value       = try(aws_iam_role.this[0].arn, null)
+}
+
+output "iam_role_name" {
+  description = "Name of IAM role"
+  value       = try(aws_iam_role.this[0].name, null)
+}
+
+output "iam_role_path" {
+  description = "Path of IAM role"
+  value       = try(aws_iam_role.this[0].path, null)
+}
+
+output "iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = try(aws_iam_role.this[0].unique_id, null)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -229,3 +229,91 @@ variable "set_sensitive" {
   type        = any
   default     = []
 }
+
+variable "set_irsa_name" {
+  description = "Value annotation name where IRSA role ARN created by module will be assigned to the `value`"
+  type        = string
+  default     = ""
+}
+
+################################################################################
+# IAM Role for Service Account(s) (IRSA)
+################################################################################
+
+variable "create_role" {
+  description = "Whether to create a role"
+  type        = bool
+  default     = false
+}
+
+variable "role_name" {
+  description = "Name of IAM role"
+  type        = string
+  default     = null
+}
+
+variable "role_name_use_prefix" {
+  description = "Determines whether the IAM role name (`role_name`) is used as a prefix"
+  type        = bool
+  default     = true
+}
+
+variable "role_path" {
+  description = "Path of IAM role"
+  type        = string
+  default     = "/"
+}
+
+variable "role_permissions_boundary_arn" {
+  description = "Permissions boundary ARN to use for IAM role"
+  type        = string
+  default     = null
+}
+
+variable "role_description" {
+  description = "IAM Role description"
+  type        = string
+  default     = null
+}
+
+variable "role_policy_arns" {
+  description = "ARNs of any policies to attach to the IAM role"
+  type        = map(string)
+  default     = {}
+}
+
+variable "oidc_providers" {
+  description = "Map of OIDC providers where each provider map should contain the `provider_arn`, and `service_accounts`"
+  type        = any
+  default     = {}
+}
+
+variable "tags" {
+  description = "A map of tags to add the the IAM role"
+  type        = map(any)
+  default     = {}
+}
+
+variable "force_detach_policies" {
+  description = "Whether policies should be detached from this role when destroying"
+  type        = bool
+  default     = true
+}
+
+variable "max_session_duration" {
+  description = "Maximum CLI/API session duration in seconds between 3600 and 43200"
+  type        = number
+  default     = null
+}
+
+variable "assume_role_condition_test" {
+  description = "Name of the [IAM condition operator](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html) to evaluate when assuming the role"
+  type        = string
+  default     = "StringEquals"
+}
+
+variable "allow_self_assume_role" {
+  description = "Determines whether to allow the role to be [assume itself](https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
### What does this PR do?

- Add initial implementation of add module which supports a helm release and IAM role for service accounts (IRSA)
	- This will eventually replace the [`helm-addon`](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/helm-addon) and [`irsa`](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/irsa) sub-modules from EKS Blueprints project
- This supports:
	- Creating a helm release + IRSA
	- Creating only a helm release
	- Creating only an IRSA
	- All resource outputs which relates to 
		- https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/892
		- https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/816
	
### Motivation

- Related to https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1032

### Test Results

<!-- Please provide supporting evidence and steps taking to test and validation this change -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->
