### PR TITLE
chore: Swap condition when using role prefix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ locals {
   partition  = data.aws_partition.current.partition
 
   role_name           = try(coalesce(var.role_name, var.name), "")
-  role_name_condition = var.role_name_use_prefix ? local.role_name : "${local.role_name}-*"
+  role_name_condition = var.role_name_use_prefix ? "${local.role_name}-*" : local.role_name
 }
 
 data "aws_iam_policy_document" "this" {


### PR DESCRIPTION
### What does this PR do?

fix logic of condition when using prefix in role name

### Motivation

- Found it reviewing the code

### Test Results

<!-- Please provide supporting evidence and steps taking to test and validation this change -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->
