### PR TITLE
fix: Ensure that IAM role creation is tied to overall `create` variable in addons sub-module

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -7,6 +7,8 @@ on:
       - edited
       - synchronize
 
+permissions: read-all
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,6 +9,8 @@ on:
       - '**.yml'
       - '**.yaml'
 
+permissions: read-all
+
 env:
   TERRAFORM_DOCS_VERSION: v0.16.0
   TFSEC_VERSION: v1.28.1

--- a/.github/workflows/stale-issue-pr.yaml
+++ b/.github/workflows/stale-issue-pr.yaml
@@ -1,8 +1,11 @@
 name: 'Stale Issue/PR'
+
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
+
+permissions: read-all
 
 jobs:
   stale:


### PR DESCRIPTION
### What does this PR do?

- Ensure that IAM role creation is tied to overall `create` variable in addons sub-module; setting `create = false` should disable all resource creation
- Set top level GitHub action workflows to `read-all` by default to pass checkov scan (required for AppSec to make public)

### Motivation

- Relates to https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/80

### Test Results

<!-- Please provide supporting evidence and steps taking to test and validation this change -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->
