### PR TITLE
fix: Handle null policy name when no policy created

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -183,7 +183,7 @@ resource "aws_iam_role_policy_attachment" "additional" {
 locals {
   create_policy = local.create_role && var.create_policy
 
-  policy_name = coalesce(var.policy_name, local.role_name)
+  policy_name = try(coalesce(var.policy_name, local.role_name), "")
 }
 
 data "aws_iam_policy_document" "this" {


### PR DESCRIPTION
### What does this PR do?

Corrects an issue where Helm-only addon fails when `policy_name` is not explicitly set

### Motivation

When attempting to use the Helm only addon feature for installing a chart (in this case `metrics-server`), the module fails during construction of the local `policy_name` due to `coalesce` being passed a null `local.role_name`. `var.name` is not set.

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Error in function call
│
│   on .terraform/modules/metrics_server_addon/main.tf line 186, in locals:
│  186:   policy_name = coalesce(var.policy_name, local.role_name)
│     ├────────────────
│     │ while calling coalesce(vals...)
│     │ local.role_name is ""
│     │ var.policy_name is null
│
│ Call to function "coalesce" failed: no non-null, non-empty-string arguments.
```

I _think_ the tests are passing because the `name` local is being configured. In `helm_release` the `name` attribute is set to either the [`var.name` or `var.chart`](https://github.com/aws-ia/terraform-aws-eks-blueprints-addon/blob/3e26c63044b27de2eadf4160b12fc7af83640c32/main.tf#L12) and the README example doesn't show using `name`, so it's a bit confusing. I'm guessing `var.name` is intended when you want to set consistent names across everything (chart, policy, roles) but in helm-only mode that doesn't seem too useful as it seems `var.chart` would be the only values required.

### Test Results

The existing tests pass because `name` local is explicitly set.

### Additional Notes

None.
