### PR TITLE
docs: Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ module "eks_blueprints_addon" {
 
   # IAM role for service account (IRSA)
   create_role = true
+  create_policy = false
   role_name   = "aws-vpc-cni-ipv4"
   role_policies = {
     AmazonEKS_CNI_Policy = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"


### PR DESCRIPTION
Tested and working. This fixes the below error with the previous example:

```
│ Error: creating IAM Policy (foo-20230823192221893600000002): MalformedPolicyDocument: Syntax errors in policy.
│ 	status code: 400, request id: 6448aac6-961f-4fe0-9b72-f37dfd22d78c
│ 
│   with module.foo.module.eks_blueprints_addon.aws_iam_policy.this[0],
│   on .terraform/modules/foo.eks_blueprints_addon/main.tf line 237, in resource "aws_iam_policy" "this":
│  237: resource "aws_iam_policy" "this" {
│ 
```

### What does this PR do?

Sets `create_policy` to false, so the module doesn't try to create a policy when the user is trying to pass in a existing policy.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #16

### Test Results

<!-- Please provide supporting evidence and steps taking to test and validation this change -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->
