### PR TITLE
feat: Add support for trust policy statements in IAM role config

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.96.1
+    rev: v1.104.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -124,6 +124,54 @@ module "eks_blueprints_addon" {
 }
 ```
 
+### Create IAM Role for Service Account (IRSA) with Extra Trust Policy Statements
+
+```hcl
+module "eks_blueprints_addon" {
+  source = "aws-ia/eks-blueprints-addon/aws"
+  version = "~> 1.0" #ensure to update this to the latest/desired version
+
+  # Disable helm release
+  create_release = false
+
+  # IAM role for service account (IRSA + extra statements)
+  create_role = true
+  role_name   = "aws-vpc-cni-ipv4"
+  role_policies = {
+    AmazonEKS_CNI_Policy = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  }
+
+  oidc_providers = {
+    this = {
+      provider_arn    = "oidc.eks.us-west-2.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE"
+      namespace       = "kube-system"
+      service_account = "aws-node"
+    }
+  }
+
+  trust_policy_statements = [
+    {
+      sid    = "PodIdentity"
+      effect = "Allow"
+      actions = [
+        "sts:AssumeRole",
+        "sts:TagSession",
+      ]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["pods.eks.amazonaws.com"]
+        }
+      ]
+    }
+  ]
+
+  tags = {
+    Environment = "dev"
+  }
+}
+```
+
 ## Support & Feedback
 
 > [!IMPORTANT]
@@ -133,7 +181,7 @@ module "eks_blueprints_addon" {
 > provided. If you are interested in contributing to EKS Blueprints, see the
 > [Contribution guide](https://github.com/aws-ia/terraform-aws-eks-blueprints-addon/blob/main/.github/CONTRIBUTING.md).
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -226,6 +274,7 @@ No modules.
 | <a name="input_source_policy_documents"></a> [source\_policy\_documents](#input\_source\_policy\_documents) | List of IAM policy documents that are merged together into the exported document. Statements must have unique `sid`s | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to `300` seconds | `number` | `null` | no |
+| <a name="input_trust_policy_statements"></a> [trust\_policy\_statements](#input\_trust\_policy\_statements) | A list of IAM policy [statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#statement) for the role trust policy | <pre>list(object({<br/>    sid           = optional(string)<br/>    actions       = optional(list(string))<br/>    not_actions   = optional(list(string))<br/>    effect        = optional(string)<br/>    resources     = optional(list(string))<br/>    not_resources = optional(list(string))<br/>    principals = optional(list(object({<br/>      type        = string<br/>      identifiers = list(string)<br/>    })))<br/>    not_principals = optional(list(object({<br/>      type        = string<br/>      identifiers = list(string)<br/>    })))<br/>    condition = optional(list(object({<br/>      test     = string<br/>      values   = list(string)<br/>      variable = string<br/>    })))<br/>  }))</pre> | `null` | no |
 | <a name="input_values"></a> [values](#input\_values) | List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options | `list(string)` | `null` | no |
 | <a name="input_verify"></a> [verify](#input\_verify) | Verify the package before installing it. Helm uses a provenance file to verify the integrity of the chart; this must be hosted alongside the chart. For more information see the Helm Documentation. Defaults to `false` | `bool` | `null` | no |
 | <a name="input_wait"></a> [wait](#input\_wait) | Will wait until all resources are in a ready state before marking the release as successful. If set to `true`, it will wait for as long as `timeout`. If set to `null` fallback on `300s` timeout.  Defaults to `false` | `bool` | `false` | no |
@@ -248,7 +297,7 @@ No modules.
 | <a name="output_revision"></a> [revision](#output\_revision) | Version is an int32 which represents the version of the release |
 | <a name="output_values"></a> [values](#output\_values) | The compounded values from `values` and `set*` attributes |
 | <a name="output_version"></a> [version](#output\_version) | A SemVer 2 conformant version string of the chart |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 ## Community
 

--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,47 @@ data "aws_iam_policy_document" "assume" {
   count = local.create_role ? 1 : 0
 
   dynamic "statement" {
+    for_each = var.trust_policy_statements != null ? var.trust_policy_statements : []
+
+    content {
+      sid           = statement.value.sid
+      actions       = statement.value.actions
+      not_actions   = statement.value.not_actions
+      effect        = statement.value.effect
+      resources     = statement.value.resources
+      not_resources = statement.value.not_resources
+
+      dynamic "principals" {
+        for_each = statement.value.principals != null ? statement.value.principals : []
+
+        content {
+          type        = principals.value.type
+          identifiers = principals.value.identifiers
+        }
+      }
+
+      dynamic "not_principals" {
+        for_each = statement.value.not_principals != null ? statement.value.not_principals : []
+
+        content {
+          type        = not_principals.value.type
+          identifiers = not_principals.value.identifiers
+        }
+      }
+
+      dynamic "condition" {
+        for_each = statement.value.condition != null ? statement.value.condition : []
+
+        content {
+          test     = condition.value.test
+          values   = condition.value.values
+          variable = condition.value.variable
+        }
+      }
+    }
+  }
+
+  dynamic "statement" {
     # https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/
     for_each = var.allow_self_assume_role ? [1] : []
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,7 +18,7 @@ $ terraform apply
 
 Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -41,6 +41,7 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 19.16 |
 | <a name="module_helm_release_irsa"></a> [helm\_release\_irsa](#module\_helm\_release\_irsa) | ../ | n/a |
 | <a name="module_helm_release_only"></a> [helm\_release\_only](#module\_helm\_release\_only) | ../ | n/a |
+| <a name="module_irsa_extra_statements"></a> [irsa\_extra\_statements](#module\_irsa\_extra\_statements) | ../ | n/a |
 | <a name="module_irsa_only"></a> [irsa\_only](#module\_irsa\_only) | ../ | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
@@ -95,6 +96,6 @@ No inputs.
 | <a name="output_irsa_only_revision"></a> [irsa\_only\_revision](#output\_irsa\_only\_revision) | Version is an int32 which represents the version of the release |
 | <a name="output_irsa_only_values"></a> [irsa\_only\_values](#output\_irsa\_only\_values) | The compounded values from `values` and `set*` attributes |
 | <a name="output_irsa_only_version"></a> [irsa\_only\_version](#output\_irsa\_only\_version) | A SemVer 2 conformant version string of the chart |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/aws-ia/terraform-aws-eks-blueprints-addon/blob/main/LICENSE).

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -139,6 +139,47 @@ module "irsa_only" {
   tags = local.tags
 }
 
+module "irsa_extra_statements" {
+  source = "../"
+
+  # Disable helm release
+  create_release = false
+
+  # IAM role for service account (IRSA + extra statements)
+  create_role = true
+  role_name   = "aws-vpc-cni-ipv4"
+  role_policies = {
+    AmazonEKS_CNI_Policy = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  }
+
+  oidc_providers = {
+    this = {
+      provider_arn    = module.eks.oidc_provider_arn
+      namespace       = "kube-system"
+      service_account = "aws-node"
+    }
+  }
+
+  trust_policy_statements = [
+    {
+      sid    = "PodIdentity"
+      effect = "Allow"
+      actions = [
+        "sts:AssumeRole",
+        "sts:TagSession",
+      ]
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["pods.eks.amazonaws.com"]
+        }
+      ]
+    }
+  ]
+
+  tags = local.tags
+}
+
 module "disabled" {
   source = "../"
 

--- a/variables.tf
+++ b/variables.tf
@@ -312,6 +312,32 @@ variable "allow_self_assume_role" {
   default     = false
 }
 
+variable "trust_policy_statements" {
+  description = "A list of IAM policy [statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#statement) for the role trust policy"
+  type = list(object({
+    sid           = optional(string)
+    actions       = optional(list(string))
+    not_actions   = optional(list(string))
+    effect        = optional(string)
+    resources     = optional(list(string))
+    not_resources = optional(list(string))
+    principals = optional(list(object({
+      type        = string
+      identifiers = list(string)
+    })))
+    not_principals = optional(list(object({
+      type        = string
+      identifiers = list(string)
+    })))
+    condition = optional(list(object({
+      test     = string
+      values   = list(string)
+      variable = string
+    })))
+  }))
+  default = null
+}
+
 ################################################################################
 # IAM Policy
 ################################################################################


### PR DESCRIPTION
### What does this PR do?

Add support for extra trust policy statements in IAM role configuration through a new `trust_policy_statements` variable.

**Changes include:**
- New `trust_policy_statements` variable in `variables.tf` with full IAM policy statement support (sid, actions, principals, conditions, etc.)
- Dynamic statement block in `main.tf` to inject custom statements into the assume role policy document
- New test module `irsa_extra_statements` demonstrating EKS Pod Identity integration
- Documentation example in README showing how to combine IRSA with Pod Identity
- Updated pre-commit hooks versions (terraform: v1.96.1 → v1.104.0, pre-commit-hooks: v4.6.0 → v6.0.0)

### Motivation

This change enables a **smooth transition from IRSA to EKS Pod Identity**. By allowing extra trust policy statements, users can configure their IAM roles to support both authentication methods simultaneously:
- Keep existing IRSA (OIDC-based) authentication working
- Add Pod Identity trust (`pods.eks.amazonaws.com`) to the same role

This approach allows teams to migrate workloads incrementally to Pod Identity without disrupting existing services.

The implementation is largely inspired by the [terraform-aws-modules/eks-pod-identity](https://registry.terraform.io/modules/terraform-aws-modules/eks-pod-identity/aws/latest) module, which uses a similar pattern for defining trust policy statements with typed objects.

### Test Results

- Added new test module `irsa_extra_statements` in `tests/main.tf`
- Pre-commit hooks pass (terraform_fmt, terraform_validate, terraform_docs)
- Example demonstrates working configuration for EKS Pod Identity

### Additional Notes

The `trust_policy_statements` variable uses a typed object structure matching the AWS IAM policy document statement schema, supporting:
- `sid`, `effect`, `actions`, `not_actions`
- `resources`, `not_resources`
- `principals`, `not_principals`
- `condition` blocks

This is fully backward compatible - existing configurations without `trust_policy_statements` will continue to work unchanged.